### PR TITLE
URIをエスケープ

### DIFF
--- a/utils/BlogService.ts
+++ b/utils/BlogService.ts
@@ -115,7 +115,7 @@ export class BlogService implements IBlogService {
   }
 
   public async getBlogsByQuery(query: string): Promise<MicroCmsResponse<IBlog>> {
-    return (await axios.get(`${config.baseUrl}/api/search?q=${query}`)).data;
+    return (await axios.get(`${config.baseUrl}/api/search?q=${encodeURIComponent(query)}`)).data;
   }
 
   public async getDraftBlog(id: string, draftKey: string): Promise<IDraftResponse> {


### PR DESCRIPTION
日本語でキーワード検索すると「TypeError: Request path contains unescaped characters」が起きるのを修正しました